### PR TITLE
Add appoint to boardType

### DIFF
--- a/_foundations/apereo.md
+++ b/_foundations/apereo.md
@@ -29,7 +29,7 @@ core:
   copyrightPolicy: "CLA"
 governance:
   boardSize: "15"
-  boardType: "elected"
+  boardType: "elected, appointed"
   boardURL: "https://www.apereo.org/content/leadership"
   membership: "purchased"
   bylawsURL: "https://www.apereo.org/content/bylaws


### PR DESCRIPTION
According to [Apereo Governance](https://www.apereo.org/governance), the board can also appoint members.